### PR TITLE
Add comments italic

### DIFF
--- a/badwolf-theme.el
+++ b/badwolf-theme.el
@@ -70,7 +70,7 @@
    ;; font lock
    `(default ((t (:inherit nil :foreground ,plain :background ,bg))))
    `(font-lock-builtin-face ((t (:foreground ,brightgravel))))
-   `(font-lock-comment-face ((t (:foreground ,lightgravel))))
+   `(font-lock-comment-face ((t (:foreground ,lightgravel :italic t))))
    `(font-lock-comment-delimiter-face ((t (:foreground ,lightgravel))))
    `(font-lock-constant-face ((t (:foreground ,orange))))
    `(font-lock-doc-face ((t (:foreground ,snow))))

--- a/badwolf-theme.el
+++ b/badwolf-theme.el
@@ -213,7 +213,12 @@
    `(erc-input-face ((t (:foreground ,dress))))
    `(erc-prompt-face ((t (:foreground ,tardis))))
    `(erc-button ((t (:inherit link))))
-   `(erc-timestamp-face ((t (:foreground ,lime))))))
+   `(erc-timestamp-face ((t (:foreground ,lime))))
+
+   ;; diff-hl
+   `(diff-hl-insert ((t (:foreground ,lime :background ,bg))))
+   `(diff-hl-delete ((t (:foreground ,taffy :background ,bg))))
+   `(diff-hl-change ((t (:foreground ,orange :background ,bg))))))
 
 ;;;###autoload
 (when load-file-name


### PR DESCRIPTION
This is a proof of concept, as maybe this could be better
implemented with a toggle option for backwards compatibility
with terminals that don't support italics.

(I would love to implement that myself since it should be dead
simple, but I'm new with elisp)

eg: 
![comments-italic-emacs](https://cloud.githubusercontent.com/assets/2196685/12992330/086c74ea-d114-11e5-81f5-7204a4bb5e55.png)
