### PR TITLE
Change whitespace marks

### DIFF
--- a/badwolf-theme.el
+++ b/badwolf-theme.el
@@ -108,10 +108,10 @@
    `(whitespace-empty ((t :background ,dirtyblonde)))
    `(whitespace-line ((t (:background ,deepergravel :foreground ,dress))))
 
-   `(whitespace-hspace ((t (:foreground ,mediumgravel))))
-   `(whitespace-space ((t (:foreground ,mediumgravel))))
-   `(whitespace-tab ((t (:foreground ,mediumgravel))))
-   `(whitespace-newline ((t (:foreground ,mediumgravel))))
+   `(whitespace-hspace ((t (:foreground ,deepgravel))))
+   `(whitespace-space ((t (:foreground ,deepgravel))))
+   `(whitespace-tab ((t (:foreground ,deepgravel))))
+   `(whitespace-newline ((t (:foreground ,deepgravel))))
 
    `(whitespace-indentation ((t (:background ,dirtyblonde :foreground ,taffy))))
    `(whitespace-space-after-tab ((t (:background ,dirtyblonde :foreground ,taffy))))


### PR DESCRIPTION
This PR changes the whitespace-marks foregrounds (tab, spaces, newlines) to one
that is between the default background color and the comments's color.

That way one can discern them easily, yet you don't confuse them with
comments.

eg: 

![whitespace-emacs](https://cloud.githubusercontent.com/assets/2196685/12992473/f84bb58e-d114-11e5-8bec-ae0ca2c41307.png)
